### PR TITLE
broaden compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureRegistries"
 uuid = "c6aefb4f-3ac3-4095-8805-528476b02c02"
 authors = ["lorenzoh <lorenz.ohly@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -15,9 +15,9 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 [compat]
 ImageShow = "0.3"
 InlineTest = "0.2"
-PrettyTables = "1"
+PrettyTables = "1, 2"
 Setfield = "0.8, 1"
-StructArrays = "0.6 - 0.6.8"
+StructArrays = "0.6"
 julia = "1"
 
 [pollen]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ImageShow = "0.3"
 InlineTest = "0.2"
 PrettyTables = "1, 2"
 Setfield = "0.8, 1"
-StructArrays = "0.6"
+StructArrays = "0.6-0.6.8,0.6.10"
 julia = "1"
 
 [pollen]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ImageShow = "0.3"
 InlineTest = "0.2"
 PrettyTables = "1, 2"
 Setfield = "0.8, 1"
-StructArrays = "0.6-0.6.8,0.6.10"
+StructArrays = "0.6.10"
 julia = "1"
 
 [pollen]


### PR DESCRIPTION
This broadens the compat bounds for both `StructArrays` and `PrettyTables`.  I assume there was a reason for the specific `StructArrays` compat bound, but this passes tests, so I'm not sure what that is.